### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // Private constructor to hide the implicit public one.
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado para o Bot de Impacto de IA da GFT para {b40fceeb276e998e5fb407ebce29ea71848f0d11}

**Descrição:** Realizamos uma atualização na classe LinkLister.java. As alterações incluíram a adição de um Logger para melhor acompanhamento de atividades e troca da saída padrão para o uso do Logger. Além disso, modificamos o construtor da classe para privado, de forma a ocultar o construtor público implícito. 

**Resumo:** 
- Arquivo src/main/java/com/scalesec/vulnado/LinkLister.java (modificado) - Adicionamos um Logger para rastreamento de atividades e substituímos a saída padrão pelo Logger. Adicionamos também um construtor privado para esconder o construtor público implícito. Além disso, removemos o tipo explícito na criação de uma nova lista ArrayList.

**Recomendação:** Recomendo que o revisor verifique se a implementação do Logger foi realizada de forma adequada e se a mudança na saída padrão para o Logger não afeta a funcionalidade geral do código. Além disso, é importante garantir que a mudança do construtor para privado não afeta a instânciação da classe LinkLister em outras partes do código. 

**Explicação das vulnerabilidades:** Não foram encontradas vulnerabilidades atuais ou que estejam sendo corrigidas nessa solicitação de pull.