### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,37 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Make sure that enabling CORS is safe here.
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Make sure that enabling CORS is safe here.
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Make sure that enabling CORS is safe here.
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+  private String body;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getBody() {
+    return body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the ba0832c03be16df1073baf5f15b6669fa9d5f4b4

**Description:** This commit modifies the `CommentsController.java` file. Changes include the modification of the CORS (Cross-Origin Resource Sharing) settings, the change of HTTP methods annotations, the encapsulation of the `CommentRequest` class fields, and the addition of getter methods.

**Summary:**
- `src/main/java/com/scalesec/vulnado/CommentsController.java` (modified)
    - CORS settings were changed from allowing all origins ("*") to only allow "http://trustedwebsite.com"
    - Replaced the `@RequestMapping` annotation with the more specific `@GetMapping`, `@PostMapping`, and `@DeleteMapping` annotations for respective methods
    - The `CommentRequest` class fields have been made private for encapsulation
    - Added getter methods for `CommentRequest` class fields
    - A newline character at the end of the file has been removed

**Recommendation:** Please review the changes, especially the CORS settings. The change now only allows requests from "http://trustedwebsite.com". If your application needs to allow requests from other domains, adjust the settings accordingly. Also, ensure that the encapsulation of the `CommentRequest` class fields does not affect other parts of your application. 

**Explanation of vulnerabilities:** The previous CORS settings were insecure because they allowed requests from any domain, which could lead to Cross-Site Scripting (XSS) or other security vulnerabilities. The change to only allow "http://trustedwebsite.com" enhances security, but make sure this doesn't limit legitimate requests.
