### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger;
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // Private constructor to hide the implicit public one.
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +31,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 642ec218da493e988158c8b77895cd254628668c
**Description:** The updates made in this pull request are mainly focused on code quality improvements in the 'LinkLister.java' file. A Logger instance was added, the implicit public constructor was hidden by adding a private constructor, and the use of System.out.println was replaced with Logger.info for better logging practices. Also, the diamond operator was used in the ArrayList initialization for type inference which makes the code cleaner and easier to read. Lastly, a new line at the end of file was removed.

**Summary:** 
- File: src/main/java/com/scalesec/vulnado/LinkLister.java (modified)
   - A Logger instance `LOGGER` was added for the `LinkLister` class.
   - A private constructor was added to hide the implicit public one.
   - System.out.println was replaced with LOGGER.info for logging the host.
   - Diamond operator was used in ArrayList initialization.
   - Removed new line at the end of file.

**Recommendation:** The changes made improve the code quality and follow best practices. Reviewers should verify if the logging level used (info) is appropriate and ensure that the removal of the new line at the end of file does not cause any issues in the code formatting or execution. Also, the use of the diamond operator should be checked for compatibility with the project's Java version. 

**Explanation of vulnerabilities:** No apparent security vulnerabilities were found or fixed in this commit. However, as always, ensure safe logging practices are followed to avoid any potential information leakage through logs.