### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,18 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 26fec6d62a4343fabcd32a6d3ac32f0bc164b36c

**Description:** The pull request 188 titled '[GFTCodeFix]: Update on src/main/java/com/scalesec/vulnado/LinksController.java' contains code cleanup and slight modifications in the LinksController.java file. Import statements have been cleaned up, removing unnecessary imports. The `RequestMapping` annotations for both `/links` and `/links-v2` have been updated to explicitly use the GET method. The last line of the file, which was just a closing bracket for the class, has been modified to not have a newline at the end of the file.

**Summary:** 
- src/main/java/com/scalesec/vulnado/LinksController.java (altered) - Removed unneeded imports, modified `RequestMapping` annotations to explicitly use GET method, and removed newline at end of file.

**Recommendation:** The changes made are straightforward and don't seem to introduce any new issues. However, it's recommended to perform regression testing to ensure that the `links` and `links-v2` endpoints are still functioning as expected with the explicit GET method declaration. 

No new vulnerabilities have been introduced or fixed with this commit.