### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,18 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 9eb02df5102a9ec6b99c2207e59ae9f83fcd3e8c
                                                
**Description:** This pull request contains changes to the LinksController.java file. The changes involve modification of import statements and `RequestMapping` annotations for the `links` and `linksV2` methods. 

**Summary:** 
- src/main/java/com/scalesec/vulnado/LinksController.java (modified) - The import statements for `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, and `java.io.Serializable` have been removed as they are not used in the code. The `RequestMapping` annotations for the `links` and `linksV2` methods have been updated to explicitly specify `RequestMethod.GET` as the HTTP method. This is more secure and understandable as it makes it clear that these endpoints are intended to handle GET requests. Also, the file no longer ends with a new line.

**Recommendation:** 
- Ensure that the removal of import statements has not affected any other parts of the code.
- Test the `links` and `linksV2` endpoints with GET requests to verify that they are working as expected after the changes.
- Add a new line at the end of the file to follow good programming conventions and avoid possible issues with certain tools that might expect or require a newline at the end of files.

**Explanation of vulnerabilities:** No new vulnerabilities have been introduced or fixed in this pull request.