### PR TITLE
[GFTCodeFix]:  Update on src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java

### DIFF
--- a/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
+++ b/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
@@ -2,16 +2,29 @@ package com.scalesec.vulnado;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class VulnadoApplicationTests {
 
-	@Test
-	public void contextLoads() {
-	}
+    @LocalServerPort
+    private int port;
 
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void contextLoads() {
+        ResponseEntity<String> response = restTemplate.getForEntity("http://localhost:" + port + "/", String.class);
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+    }
 }
-


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the b7b76d7838b74f301a2a956ba73115c69e32b684

**Description:** This pull request shows modifications to the file 'src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java'. The changes include the addition of new import statements and the modification of the `VulnadoApplicationTests` class. The SpringBootTest annotation has been updated to specify a random web environment port. A local server port variable and a restTemplate have been added. The `contextLoads` method has also been redefined to test for a 200 status code response from the application's root URL.

**Summary:** 
- src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java (modified)
  - Added new import statements for `org.springframework.beans.factory.annotation.Autowired`, `org.springframework.boot.test.context.SpringBootTest.WebEnvironment`, `org.springframework.boot.web.server.LocalServerPort`, `org.springframework.boot.test.web.client.TestRestTemplate`, `org.springframework.http.ResponseEntity`, `static org.assertj.core.api.Assertions.assertThat`.
  - Updated the `SpringBootTest` annotation on `VulnadoApplicationTests` class to specify a random web environment port.
  - Added a local server port variable and a restTemplate.
  - Redefined the `contextLoads` method to test for a 200 status code response from the application's root URL.

**Recommendation:** The changes appear to be sound and are aimed at improving the testing of the `VulnadoApplication`. Reviewers should check the new import statements and the redefined `contextLoads` method. It would be beneficial to ensure the test checks for the correct status code and that the application's root URL is correctly referenced. 

Please note that the file appears to be missing a newline at the end. This may not necessarily cause issues in Java, but it's a common coding standard in many languages. Consider adding a newline at the end of the file for consistency and to adhere to this standard.