### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,18 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado para GFT AI Impact Bot para o {83ebe5b51bebbc130bd36de07de77d42c6cea989}

**Descrição:** Neste pull request, foram feitas alterações no arquivo LinksController.java. As importações para org.springframework.boot e java.io.Serializable foram removidas, assim como a importação para org.springframework.http.HttpStatus. Além disso, as rotas "/links" e "/links-v2" agora especificam explicitamente que estão usando o método GET.

**Resumo:** 
- Arquivo src/main/java/com/scalesec/vulnado/LinksController.java (alterado): A importação para org.springframework.boot.*, org.springframework.http.HttpStatus e java.io.Serializable foram removidas. As rotas "/links" e "/links-v2" agora especificam que estão usando o método GET. 

**Recomendação:** Recomendo revisar as alterações para garantir que a remoção das importações não afete a funcionalidade existente. Além disso, certifique-se de que a mudança nas rotas para especificar o método GET está alinhada com as expectativas do projeto. Teste as rotas alteradas para garantir que elas estejam funcionando conforme o esperado.

**Explicação de vulnerabilidades:** Não foram encontradas vulnerabilidades atuais ou que estejam sendo corrigidas neste pull request.