### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,34 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+  private String body;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getBody() {
+    return body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado para GFT AI Impact Bot para o {08f2bc787a94e24c6e2123ca725b93e03b3bb813}
                                                
**Descrição:** Este Pull Request faz uma atualização no arquivo `src/main/java/com/scalesec/vulnado/CommentsController.java`. As principais mudanças foram a substituição dos métodos de requisição HTTP (`@RequestMapping`) por anotações mais específicas (`@GetMapping`, `@PostMapping` e `@DeleteMapping`), a remoção da anotação `@CrossOrigin(origins = "*")` e a alteração dos atributos `public` para `private` na classe `CommentRequest`, além de adicionar métodos getter para esses atributos.

**Resumo:** 

- Arquivo `src/main/java/com/scalesec/vulnado/CommentsController.java` (alterado) - Substituição dos métodos `@RequestMapping` por anotações mais específicas (`@GetMapping`, `@PostMapping` e `@DeleteMapping`), remoção da anotação `@CrossOrigin(origins = "*")` e modificação dos atributos `public` para `private` na classe `CommentRequest`, com a adição de métodos getter para esses atributos.

**Recomendação:** Recomendo uma revisão cuidadosa para verificar se a remoção da anotação `@CrossOrigin(origins = "*")` não afeta a funcionalidade do código, já que essa anotação permite solicitações de qualquer origem. Além disso, é importante verificar se a substituição dos métodos de requisição HTTP (`@RequestMapping`) por anotações mais específicas (`@GetMapping`, `@PostMapping` e `@DeleteMapping`) não altera o comportamento esperado do programa. 

**Explicação de vulnerabilidades:** N/A