### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // private constructor to hide the implicit public one
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado para o Bot de Impacto de IA da GFT para o 0489eb2dc6c29c4252f21aa468a22674380b5c69
**Descrição:** Neste commit, foram realizadas algumas mudanças no arquivo src/main/java/com/scalesec/vulnado/LinkLister.java. Foi adicionado um logger, construtor privado para esconder o construtor público implícito e alterado o tipo de impressão do host.

**Resumo:**
- Arquivo src/main/java/com/scalesec/vulnado/LinkLister.java (alterado)
  - Foi adicionado o Logger para registrar informações
  - Adicionado um construtor privado para esconder o construtor público implícito
  - Substituição do System.out.println pelo LOGGER.info para imprimir o host
  - Alterado a declaração da lista de resultado para o tipo genérico `<>`
  - Ajuste na última linha para não haver nova linha no final do arquivo

**Recomendação:** Recomendo revisar as alterações realizadas para garantir que o uso do Logger esteja conforme o esperado e que a alteração no tipo de impressão do host não impacte em outras partes do código que dependam dessa informação. Recomendo também realizar testes para garantir que a funcionalidade da classe LinkLister continua a mesma após as alterações.

**Explicação de vulnerabilidades:** Não foram identificadas vulnerabilidades no código alterado.