### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,18 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado pelo GFT AI Impact Bot para o commit id 921ea79d52c8fcb5ce62870af60c4e25a8dd1b4b

**Descrição:** Esta solicitação de pull request faz atualizações no arquivo src/main/java/com/scalesec/vulnado/LinksController.java. Algumas importações não utilizadas foram removidas e os métodos de requisição foram especificados para as rotas "/links" e "/links-v2". Além disso, a formatação do arquivo foi ajustada, removendo uma linha em branco e corrigindo a falta de nova linha no final do arquivo.

**Resumo:**
- src/main/java/com/scalesec/vulnado/LinksController.java (modificado) - Foram removidas as importações não utilizadas de "org.springframework.boot.*", "org.springframework.http.HttpStatus" e "java.io.Serializable". Além disso, foram especificados os métodos de requisição (GET) para as rotas "/links" e "/links-v2". Por fim, foi corrigida a formatação do arquivo, removendo uma linha em branco e adicionando uma nova linha no final do arquivo.

**Recomendação:** Recomendo que o revisor verifique as alterações, certificando-se de que a remoção das importações não afeta outras partes do código e que a especificação dos métodos de requisição está correta. Além disso, sugiro que o revisor confirme que a nova formatação do arquivo está em conformidade com as diretrizes de estilo de código do projeto.