### PR TITLE
[GFTCodeFix]:  Update on src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java

### DIFF
--- a/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
+++ b/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
@@ -2,16 +2,29 @@ package com.scalesec.vulnado;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class VulnadoApplicationTests {
 
-	@Test
-	public void contextLoads() {
-	}
+    @LocalServerPort
+    private int port;
 
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void contextLoads() {
+        ResponseEntity<String> response = restTemplate.getForEntity("http://localhost:" + port + "/", String.class);
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+    }
 }
-


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado pelo GFT AI Impact Bot para o commit {5259918de2f753e5fc04ecedc64342eeff116ec3}
                                                **Descrição:** A request pull atualiza o arquivo 'VulnadoApplicationTests.java', adicionando várias importações e modificando a anotação '@SpringBootTest' para incluir um ambiente web com porta aleatória. Além disso, adiciona um novo método de teste 'contextLoads' que faz uma solicitação GET para o servidor local na porta definida e verifica se o código de resposta é 200.
                                                \n
                                                **Resumo:** - src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java (alterado) - As importações foram adicionadas para permitir a realização de testes de requisições HTTP e verificar a resposta. A anotação '@SpringBootTest' foi atualizada para incluir um ambiente web com porta aleatória. O método de teste 'contextLoads' foi modificado para realizar uma solicitação GET para o servidor local na porta definida e verificar se o código de resposta é 200.
                                                \n
                                                **Recomendação:** Verifique se a porta definida para os testes não conflita com nenhuma outra porta já em uso. Além disso, garanta que o servidor esteja corretamente configurado para responder com o código 200 para a solicitação GET realizada.
                                                \n
