### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // Private constructor to hide the implicit public one.
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 4aea94bdea6487497220b37da58007f88a41793d
**Description:** The pull request includes modifications to the LinkLister.java file, which mainly involve logging adjustments and syntax improvements.

**Summary:**
- src/main/java/com/scalesec/vulnado/LinkLister.java (modified): A Logger instance was added to log information instead of printing it directly to the console. A private constructor was added to hide the implicit public one, following the best practice for utility classes. The syntax for creating a new ArrayList has been updated to use diamond operator. The System.out.println statement has been replaced by LOGGER.info to log the host information. Finally, a new line at the end of the file was removed.

**Recommendation:** I recommend reviewing the logging level used (info) to ensure it is appropriate for the type of information being logged. Additionally, make sure that the syntax updates align with the team's coding style guidelines. 

**Explanation of vulnerabilities:** No new vulnerabilities were introduced or fixed in this pull request.