### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,18 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 92e9dc3eab31bf3f5e5d05f98da5f2055971e7cf

**Description:** The Pull Request contains changes in the `LinksController.java` file. The changes include modification of import statements and `@RequestMapping` annotations. The import statements for `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, and `java.io.Serializable` have been removed. The `@RequestMapping` annotation for both `links` and `links-v2` methods has been changed to explicitly specify the HTTP method as GET and the output format as JSON.

**Summary:** 

- File: src/main/java/com/scalesec/vulnado/LinksController.java (modified)
   - Removed import statements: `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, and `java.io.Serializable`
   - Changed `@RequestMapping` annotation for `links` and `links-v2` methods to include HTTP method and output format.

**Recommendation:** Review the changes and ensure that removing the import statements do not affect any other parts of the code. Also, verify that changing the `@RequestMapping` annotation to explicitly specify the HTTP method as GET and the output format as JSON aligns with the application's requirements and functionality. Run unit tests to confirm the correct operation of the modified methods.

**Explanation of vulnerabilities:** None detected in this commit.