### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,30 +13,34 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @CrossOrigin(origins = "http://localhost")
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @CrossOrigin(origins = "http://localhost")
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @CrossOrigin(origins = "http://localhost")
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+public String getUsername() { return username; }
+  private String body;
+public String getBody() { return body; }
+public void setUsername(String username) { this.username = username; }
 }
+public void setBody(String body) { this.body = body; }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 class BadRequest extends RuntimeException {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the fbdfe0988b06704567da40a913e9a95bcb4f6389

**Description:** This PR includes changes to the `CommentsController.java` file. The changes are primarily about refactoring some methods and changing the scope of certain variables. The `@CrossOrigin` annotation has been updated to only accept requests from `http://localhost` instead of any origin. The `@RequestMapping` annotations have been changed to `@GetMapping`, `@PostMapping`, and `@DeleteMapping` for better readability and understanding of the method's purpose. Additionally, the `username` and `body` fields in the `CommentRequest` class are now private and they are accessed using getter and setter methods.

**Summary:** 

- `CommentsController.java` (modified)
    - `@CrossOrigin` annotation updated to accept requests only from `http://localhost`.
    - `@RequestMapping` replaced with `@GetMapping`, `@PostMapping`, and `@DeleteMapping` for specific methods.
    - `username` and `body` fields in `CommentRequest` class are now private and accessed via getter and setter methods.

**Recommendation:** Please review the changes thoroughly, especially the change in `@CrossOrigin` annotation as it now only accepts requests from `localhost`. Ensure that this change doesn't affect any other part of the application and the functionality remains intact. Test the application thoroughly to ensure that the changes have not introduced any new issues. 

**Explanation of vulnerabilities:** There don't appear to be any direct vulnerabilities introduced or fixed by this PR. However, restricting `@CrossOrigin` to `localhost` can help in reducing the attack surface by not allowing requests from unknown origins.