### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // private constructor to hide the implicit public one
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) 
Generated for GFT AI Impact Bot for the 1a756fa697ce8e3c7e651980c900520e5d3d82a1

**Description:** This commit introduced some updates to the LinkLister.java class. The changes include the addition of a Logger, a private constructor, and some modifications in the `getLinks` and `getLinksV2` methods.

**Summary:**
- src/main/java/com/scalesec/vulnado/LinkLister.java (modified)
  - A Logger object was added to handle logging needs.
  - A private constructor was added to hide the implicit public one.
  - The `getLinks` method: the ArrayList initialization syntax was simplified.
  - The `getLinksV2` method: the System.out.println statement was replaced by a Logger.info call to log the host information.
  - The file now does not have a newline at the end.

**Recommendation:** The changes appear to be well implemented. However, it would be advisable to test the revised methods to ensure they still function as expected. Also, ensure that the logger is correctly set up and logs as required.

**Explanation of vulnerabilities:** No security vulnerabilities were detected in this commit. However, it is recommended to ensure that the Logger does not log sensitive information, as this could potentially be exploited.