### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,18 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 0e024d60979c3e5b0b625d1219fba132f2c2dd9f

**Description:** The Pull Request titled '[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java' includes modifications to the 'LinksController.java' file. The changes primarily focus on cleaning up the import statements and altering the request mapping annotations for two methods. 

**Summary:** 
- src/main/java/com/scalesec/vulnado/LinksController.java (modified) - The following changes have been made:
    - Unused import statements have been removed.
    - The @RequestMapping annotation for the 'links' and 'links-v2' methods have been updated to specify the HTTP method as 'GET'.
    - Removed the newline at the end of the file.

**Recommendation:** There don't appear to be any significant issues with the changes. However, it would be advisable to ensure the removal of import statements doesn't impact other parts of the code. Further, confirm that changing the request mapping to specifically use 'GET' method doesn't affect the functionality where these endpoints are consumed. Lastly, it's generally good practice to include a newline at the end of a file to avoid any potential issues with UNIX systems and certain tools which expect or require it.

**Explanation of vulnerabilities:** There don't appear to be any security vulnerabilities introduced or fixed with this commit. However, it's always important to ensure changes to endpoint configurations don't unintentionally expose sensitive data or functionality.