### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,16 +1,19 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger LOGGER = LoggerFactory.getLogger(User.class);
+  private String id;
+  private String username;
+  private String hashedPassword;
 
   public User(String id, String username, String hashedPassword) {
     this.id = id;
@@ -18,10 +21,21 @@ public class User {
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() {
+    return id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getHashedPassword() {
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact();
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,41 +45,40 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      LOGGER.error(e.getMessage(), e);
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null;
     User user = null;
-    Connection cxn = null; // Incluido por GFT AI Impact Bot
+    Connection cxn = null;
     try {
-      cxn = Postgres.connection(); // Alterado por GFT AI Impact Bot
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
+      cxn = Postgres.connection();
+      LOGGER.info("Opened database successfully");
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      String query = "select * from users where username = ? limit 1";
+      stmt = cxn.prepareStatement(query);
+      stmt.setString(1, un);
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
-        String user_id = rs.getString("user_id");
+        String userId = rs.getString("user_id");
         String username = rs.getString("username");
         String password = rs.getString("password");
-        user = new User(user_id, username, password);
+        user = new User(userId, username, password);
       }
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
-      return null; // Alterado por GFT AI Impact Bot
+      LOGGER.error(e.getClass().getName()+": "+e.getMessage(), e);
+      return null;
     } finally {
       try {
-        if (stmt != null) stmt.close(); // Incluido por GFT AI Impact Bot
-        if (cxn != null) cxn.close(); // Incluido por GFT AI Impact Bot
+        if (stmt != null) stmt.close();
+        if (cxn != null) cxn.close();
       } catch (Exception e) {
-        e.printStackTrace();
+        LOGGER.error(e.getMessage(), e);
       }
     }
-    return user; // Alterado por GFT AI Impact Bot
+    return user;
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 707a8c08fa74d9935d96b4dc976d7e6110ba6e50
**Description:** The pull request is proposing modifications to the User.java class within the com.scalesec.vulnado package. The changes seem to be aimed at improving code quality, enhancing security, and adding logging capabilities.

**Summary:**
- `src/main/java/com/scalesec/vulnado/User.java` (modified): 
    - Replaced the usage of `java.sql.Statement` with `java.sql.PreparedStatement` to prevent SQL Injection attacks.
    - Added getters for the private fields `id`, `username`, and `hashedPassword`.
    - Added a `Logger` to replace the standard error and print statements for better logging and debugging.
    - Encapsulated the fields `id`, `username`, and `hashedPassword` by changing their access modifiers to private.
    - Modified the `fetch` method to use `PreparedStatement` instead of `Statement` and parameterized SQL queries.
    - Removed print statements and replaced them with appropriate logging statements.
    - Exception handling improved to log errors instead of printing stack trace.

**Recommendation:** 
- Reviewers should check the changes made, especially in the `fetch` method where SQL queries were changed to use `PreparedStatement`. They should ensure that the change does not affect the application's functionality.
- Also, reviewers should verify that the logging has been correctly set up and is functioning as expected.
- It's recommended to add unit tests to validate the changes made in this pull request.

**Explanation of vulnerabilities:** 
- The original code was susceptible to SQL Injection attacks due to the usage of `java.sql.Statement`. This was resolved by replacing it with `java.sql.PreparedStatement`, which supports parameterized queries. This change mitigates the risk of SQL Injection attacks.