### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // private constructor to hide the implicit public one
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 945ea1fe724edf38ea72a259cfe261b1ffeacd3a
                                                
**Description:** The changes made in the 'src/main/java/com/scalesec/vulnado/LinkLister.java' file are primarily related to code quality improvements and logging changes. Specifically, a private constructor was added to hide the implicit public one which is a best practice in Java for utility classes. Additionally, the system print statement for printing the host was replaced with a Logger statement for better logging management. Lastly, a minor change was made to use the diamond operator, which is a newer and more concise way to instantiate generic classes in Java.

**Summary:** 

- `src/main/java/com/scalesec/vulnado/LinkLister.java` (modified) - The changes include the addition of a private constructor to hide the implicit public one, replacing system print statements with Logger statements for better logging, and using the diamond operator for more concise generic class instantiation.

**Recommendation:** I recommend verifying the functionality and logging of the 'LinkLister' class after these changes. Ensure that the host is being logged correctly and the generic classes are being instantiated correctly with the diamond operator. Also, ensure that the addition of the private constructor does not affect the functionality of the class in any way.

**Explanation of vulnerabilities:** No security vulnerabilities were introduced or fixed in this commit. The changes were primarily for code quality and logging improvements.